### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,32 @@
 # Html Battle Window
-To build via terminal use in the root **gradlew hist:dist**
 
-then place the html and WEB-INF files in /public/battle/
+###Requirements
+
+On Linux:
+
+```
+sudo apt-get install gradle
+```
+
+On Windows, install `chocolatey` and then in administrative command line:
+
+```
+choco install gradle
+```
+
+###Build
+
+On Linux:
+```
+chmod +x gradlew
+./gradlew html:dist
+```
+
+On Windows:
+```
+gradlew.bat html:dist
+```
+
+###Run
+
+This is not a stand-alone repository. It is used as a submodule of `po-devs/po-web`.


### PR DESCRIPTION
I also did some change in the webclient repo:
- submodule moved from `html` to `animated-battle-window`
- `grunt copy` will copy all the appropriate files from `animated-battle-window/` to `public/battle/`

Also maybe later change this repo's name from `html` to something better? Eventually it'll be good if it can be included as a submodule in both the webclient and the android one.
