### PR TITLE
Show pokemon name when nickname has invalid characters

### DIFF
--- a/core/src/com/mygdx/game/battlewindow/ContinuousGameFrame.java
+++ b/core/src/com/mygdx/game/battlewindow/ContinuousGameFrame.java
@@ -11,6 +11,12 @@ import com.badlogic.gdx.scenes.scene2d.ui.Image;
 import com.badlogic.gdx.utils.Array;
 import com.mygdx.game.Bridge;
 
+/*
+    Core application.
+
+    Uses a bridge (Html, Desktop or Android) to interface with particular platform.
+
+ */
 public class ContinuousGameFrame extends ApplicationAdapter implements InputProcessor {
     private static final String TAG = "ContinuousGameFrame";
     public TaskService service;
@@ -76,6 +82,7 @@ public class ContinuousGameFrame extends ApplicationAdapter implements InputProc
 
     Event event;
 
+    /* Main rendering loop */
     @Override
     public void render() {
         delta = Gdx.graphics.getDeltaTime();
@@ -142,6 +149,7 @@ public class ContinuousGameFrame extends ApplicationAdapter implements InputProc
         */
     }
 
+    /* Calculate sprite positions depending on dimensions of the window */
     private void calculateGUI() {
         batch = new SpriteBatch();
 

--- a/core/src/com/mygdx/game/battlewindow/SpriteAnimation.java
+++ b/core/src/com/mygdx/game/battlewindow/SpriteAnimation.java
@@ -9,8 +9,6 @@ import com.badlogic.gdx.utils.Array;
 
 public class SpriteAnimation extends Animation {
 
-
-
     public SpriteAnimation(float frameDuration, Array<? extends TextureRegion> keyFrames) {
         super(frameDuration, keyFrames);
     }

--- a/html/src/com/mygdx/game/client/JavaScriptPokemon.java
+++ b/html/src/com/mygdx/game/client/JavaScriptPokemon.java
@@ -71,6 +71,10 @@ public class JavaScriptPokemon extends JavaScriptObject implements JSONPoke {
         return this.name;
     }-*/;
 
+    private native String pokemonName() /*-{
+        return $wnd.pokeinfo.name(this);
+    }-*/;
+
     private native short getNum() /*-{
         return this.num;
     }-*/;
@@ -96,7 +100,24 @@ public class JavaScriptPokemon extends JavaScriptObject implements JSONPoke {
     }-*/;
 
     public static native JavaScriptPokemon fromJS(String json) /*-{
-        return eval('(' + json + ')');
+        var ret = eval('(' + json + ')');
+
+        //Change the name if it contains illegal characters. A regex would probably do the same job
+        var name = ret.name;
+        for (var i in name) {
+            var chr = name.charCodeAt(i);
+            if (chr >= 32 && chr <= 126) {
+                continue;
+            }
+            if (chr == 3 || chr == 4 || chr == 15 || (chr >= 11 && chr <= 13)
+                    || chr == 166 || chr == 167 || chr == 173) {
+                continue;
+            }
+            ret.name = $wnd.pokeinfo.name(ret);
+            break;
+        }
+
+        return ret;
     }-*/;
 
     public static native String pokemonName(int num) /*-{


### PR DESCRIPTION
Now if a nickname has any character invalid it'll show the pokemon name.

I set it once on object load since I assumed it wouldn't be good to do it every time on name request, but I'm not certain!

Fix #7
