### PR TITLE
Remove debug frames in Html

### DIFF
--- a/core/src/com/mygdx/game/Bridge.java
+++ b/core/src/com/mygdx/game/Bridge.java
@@ -20,4 +20,5 @@ public interface Bridge {
     /* Event will be played as soon as the current event finishes */
     public void addImmediateEvent(Event event);
     public void log(String text);
+    public boolean isDebug();
 }

--- a/core/src/com/mygdx/game/battlewindow/ContinuousGameFrame.java
+++ b/core/src/com/mygdx/game/battlewindow/ContinuousGameFrame.java
@@ -149,7 +149,9 @@ public class ContinuousGameFrame extends ApplicationAdapter implements InputProc
                 objectDebugger.end();
                 Gdx.gl20.glDisable(GL20.GL_BLEND);
                 */
-                renderDebugObjects();
+                if (bridge.isDebug()) {
+                    renderDebugObjects();
+                }
                 break;
             }
             case STATUS_PAUSED: {

--- a/desktop/src/com/mygdx/game/desktop/DesktopLauncher.java
+++ b/desktop/src/com/mygdx/game/desktop/DesktopLauncher.java
@@ -96,6 +96,11 @@ public class DesktopLauncher {
 			}
 		}
 
+        @Override
+        public boolean isDebug() {
+            return true;
+        }
+
 		@Override
 		public TextureAtlas getAtlas(String path) {
 			return new TextureAtlas(Gdx.files.internal(path));

--- a/html/src/com/mygdx/game/client/HtmlLauncher.java
+++ b/html/src/com/mygdx/game/client/HtmlLauncher.java
@@ -91,6 +91,11 @@ public class HtmlLauncher extends GwtApplication {
             unpausebattle();
         }
 
+        @Override
+        public native boolean isDebug() /*-{
+            return $wnd.battle.debug || false;
+        }-*/;
+
         private native void pausebattle() /*-{
             console.log("html pause");
             $wnd.battle.pause();


### PR DESCRIPTION
They can still be easily added by doing `battle.debug = true` in battle-canvas.kiwi in the webclient.

And they're still on (by default) on the desktop.
